### PR TITLE
workflows: add permissions to upload SARIF files

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,10 @@ on:
     - cron: "18 3 * * 2"
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/shiftleft-analysis.yml
+++ b/.github/workflows/shiftleft-analysis.yml
@@ -7,6 +7,10 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   Scan-Build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request mainly updates the GitHub Actions workflow files, specifically `.github/workflows/codeql-analysis.yml` and `.github/workflows/shiftleft-analysis.yml`. The changes involve adding permissions to these workflows, allowing them to read contents and write security events.

Here are the key changes:

GitHub Actions Permissions:

* <a href="diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R12-R15">`.github/workflows/codeql-analysis.yml`</a>: Added permissions to read contents and write security events. This allows the CodeQL analysis workflow to have necessary access for its operation.
* <a href="diffhunk://#diff-210eab0593c262f7d47609bfa7c63c39fc3feca1c7b4f77b87c31351c4668565R10-R13">`.github/workflows/shiftleft-analysis.yml`</a>: Similar to the CodeQL workflow, permissions were added to read contents and write security events, enabling the ShiftLeft analysis workflow to function properly.